### PR TITLE
[infra] Install alpine riscv64 sysroot

### DIFF
--- a/build/linux/alpine_sysroot_scripts/install-sysroot.sh
+++ b/build/linux/alpine_sysroot_scripts/install-sysroot.sh
@@ -21,7 +21,7 @@ SCRIPT="$(readlink -f -- "$0")"
 WORKDIR="$(dirname -- "$(dirname -- "$(dirname -- "$(dirname -- "$SCRIPT")")")")"
 
 if test $# -eq 0; then
-  set aarch64 armv7 x86_64 x86
+  set aarch64 armv7 x86_64 x86 riscv64
 fi
 
 echo "$@" | xargs -n 1 -- sh -xc 'apk add --root "$1/buildtools/sysroot/alpine-linux-$2" --repositories-file /etc/apk/repositories --allow-untrusted --arch "$2" --no-cache --no-scripts --initdb -- build-base linux-headers' -- "$WORKDIR"


### PR DESCRIPTION
This PR updates the alpine-linux sysroot install script to also install `riscv64` by default. `riscv64` wasn't part of the default because it was only supported in `alpine:edge`, but not in `alpine:stable`. With recently released alpine stable 3.20, `riscv64` support is now stable: https://alpinelinux.org/posts/Alpine-3.20.0-released.html